### PR TITLE
feat: 가이드 리스트 프로젝션 쿼리 추가

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -130,7 +130,12 @@ apiRouter.get('/getGuideData', async (req, res) => {
   const getData = await db.collection('guide').find().toArray();
   res.send(getData);
 });
-export default apiRouter;
+
+apiRouter.get(`/getGuideList`, async (req, res) => {
+  const db = client.db('BP');
+  const getData = await db.collection('guide').find().project({_id: 0, category: 1, title: 1}).toArray();
+  res.send(getData);
+});
 
 apiRouter.post('/deleteGuideData', async (req, res) => {
   const {title} = req.body;
@@ -217,3 +222,5 @@ apiRouter.post('/updateDatabase', async (req, res) => {
     )
     .catch(err => console.error(err));
 });
+
+export default apiRouter;


### PR DESCRIPTION
## 작업내용

- 가이드 리스트 프로젝션 쿼리 추가
<br>

## 주요 변경점

- 프론트 페이지에서 가이드 사이드바에 가져올, 가이드 리스팅 API 작성
<br>

## 유의할 점 (optional)

- 기존의 코드에서는 가이드의 모든 데이터를 싸그리 불러온 후, 프론트에서 이름만 추출해서 사이드바를 리스팅하는 방식이였습니다.
그런데, 데이터 리스트에서 필요한 제목 필드만 추출하여 보낼 수 있다면 요청 성능을 개선할 수 있습니다.

- 알고보니 당연히 find메서드에 이를 위한 기능이 있었고, projection이라고 하더라구요. 해당 기능 사용해 데이터 리스팅 api 추가했습니다.
저희가 프론트 페이지를 React-query로 구조변경하기 위해서는 해당 작업이 필요하기에 적용했습니다.

- React-query로 구조변경을 할때, 지금처럼 한번에 모든 데이터를 불러와 캐싱하는게 아니라,
각 페이지마다 상응하는 데이터를 요청하고 받은 데이터를 스테이트에 저장하려고 합니다. ( 이 방법이 효율적이라 생각합니다 )

- 그렇기에 사이드바를 리스팅할 때, 
기존처럼 모든 데이터의 필드를 한번에 불러와 이름을 추출하는 방식은 필요가 없어졌습니다.
뿐만 아니라 기존의 방식을 React-query랑 같이 쓰면 구조 상 결함이 되어버리기에, 해당 방법을 적용했습니다.
<br>

## To Reviewers (optional)

- 
